### PR TITLE
fix npm script "build".

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "mignonstyle",
   "license": "GPLv2",
   "scripts": {
-    "build": "./node_modules/gulp/bin/gulp.js",
+    "build": "gulp",
     "miya": "echo 'おいこらー！'"
   },
   "browserify-shim": {


### PR DESCRIPTION
npm script のなかでは、node_modules/.bin  へのパスが通っているので、gulp のみで ok. グローバルにgulpコマンドが無くても動く。
